### PR TITLE
feat(design): improve reading surface, blog layout and bio visual def…

### DIFF
--- a/app/(site)/bio/page.tsx
+++ b/app/(site)/bio/page.tsx
@@ -52,16 +52,16 @@ export default function BioPage() {
               Franco Balich
             </h1>
 
-            <div className="grid grid-cols-1 md:grid-cols-[200px_1fr] gap-10 items-start">
+            <div className="grid grid-cols-1 md:grid-cols-[260px_1fr] gap-10 items-start">
               {/* Foto */}
               <div className="flex flex-col items-center md:items-start gap-3">
-                <div className="relative w-44 h-44 md:w-48 md:h-48 rounded-2xl overflow-hidden border border-blue-500/20 glow-blue flex-shrink-0">
+                <div className="relative w-52 h-52 md:w-64 md:h-64 rounded-2xl overflow-hidden border border-blue-500/20 glow-blue flex-shrink-0">
                   <Image
                     src="/images/profile/franco.jpeg"
                     alt="Franco Balich — foto oficial"
                     fill
                     className="object-cover object-top"
-                    sizes="(max-width: 768px) 176px, 192px"
+                    sizes="(max-width: 768px) 208px, 256px"
                     priority
                   />
                 </div>
@@ -155,31 +155,24 @@ export default function BioPage() {
             </GlassCard>
           </section>
 
-          {/* ── Bloque 4.5: Social proof ── */}
-          <section aria-label="Organizaciones y eventos">
-            <h2 className="text-2xl font-bold text-zinc-100 mb-2">
-              Eventos y organizaciones
-            </h2>
-            <p className="text-zinc-500 text-sm mb-8">
-              Eventos donde participé como speaker, instructor o panelista.
-            </p>
-            <GlassCard hover={false} className="p-10 text-center">
-              <p className="text-zinc-600 text-sm">Logos de eventos — próximamente</p>
-            </GlassCard>
-          </section>
-
           {/* ── Bloque 3: Galería de fotos ── */}
           <section aria-label="Galería de fotos">
             <h2 className="text-2xl font-bold text-zinc-100 mb-2">
               Galería
             </h2>
             <p className="text-zinc-500 text-sm mb-8">
-              Fotos en eventos, charlas y el laboratorio. Disponibles para uso
-              en medios con crédito.
+              Fotos en eventos, charlas y el laboratorio. Disponibles para uso en medios con crédito.
             </p>
-            <GlassCard hover={false} className="p-10 text-center">
-              <p className="text-zinc-600 text-sm">Fotos — próximamente</p>
-            </GlassCard>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="aspect-[4/3] min-h-[120px] rounded-2xl bg-zinc-900 border border-white/[0.10] flex items-center justify-center overflow-hidden"
+                >
+                  <span className="text-zinc-600 text-xs">Foto próximamente</span>
+                </div>
+              ))}
+            </div>
           </section>
 
           {/* ── Bloque 4 + 6: Kit de prensa ── */}

--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -152,70 +152,77 @@ export default async function PostPage({ params }: Props) {
       />
       <Navbar />
       <main className="pt-24 pb-24">
-        <div className="max-w-[680px] mx-auto px-6">
+        <div className="max-w-[960px] mx-auto px-6">
 
-          <header className="mb-10">
-            <div className="flex items-center gap-2 text-xs text-zinc-600 mb-4">
-              <Link href="/blog" className="hover:text-zinc-400 transition-colors">
-                Blog
-              </Link>
-              <span>/</span>
-              <span className="text-zinc-500">{post.title}</span>
-            </div>
+          {/* Breadcrumb — outside the reading card */}
+          <div className="flex items-center gap-2 text-xs text-zinc-500 mb-6">
+            <Link href="/blog" className="hover:text-zinc-300 transition-colors">
+              Blog
+            </Link>
+            <span className="text-zinc-600">/</span>
+            <span className="text-zinc-400 truncate">{post.title}</span>
+          </div>
 
-            <div className="flex flex-wrap gap-1.5 mb-5">
-              {tags.map((tag: string) => (
-                <Badge key={tag} variant="blue">
-                  {tag}
-                </Badge>
-              ))}
-            </div>
+          {/* Reading surface card */}
+          <div className="bg-zinc-800/50 border border-zinc-700/60 rounded-3xl px-8 md:px-14 py-10 md:py-12 mb-10 backdrop-blur-sm">
 
-            <h1 className="text-3xl md:text-4xl font-bold text-zinc-100 leading-tight mb-4">
-              {post.title}
-            </h1>
+            <header className="mb-10">
+              <div className="flex flex-wrap gap-1.5 mb-5">
+                {tags.map((tag: string) => (
+                  <Badge key={tag} variant="blue">
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
 
-            <div className="flex items-center gap-3 text-sm text-zinc-500 pb-6 border-b border-white/[0.06]">
-              {publishedAt && (
-                <>
-                  <time dateTime={publishedAt}>{formatDate(publishedAt)}</time>
-                  <span>·</span>
-                </>
-              )}
-              <span>
-                {Math.max(1, Math.round(contentHtml.split(/\s+/).length / 200))} min de lectura
-              </span>
-            </div>
-          </header>
+              <h1 className="text-3xl md:text-4xl font-bold text-zinc-100 leading-tight mb-4">
+                {post.title}
+              </h1>
 
-          {coverUrl && (
-            <div className="relative w-full h-64 md:h-80 rounded-2xl overflow-hidden mb-10 border border-white/[0.06]">
-              <Image
-                src={coverUrl}
-                alt={post.title}
-                fill
-                className="object-cover"
-                sizes="(max-width: 768px) 100vw, 680px"
-                priority
-              />
-            </div>
-          )}
+              <div className="flex items-center gap-3 text-sm text-zinc-500 pb-6 border-b border-white/[0.06]">
+                {publishedAt && (
+                  <>
+                    <time dateTime={publishedAt}>{formatDate(publishedAt)}</time>
+                    <span>·</span>
+                  </>
+                )}
+                <span>
+                  {Math.max(1, Math.round(contentHtml.split(/\s+/).length / 200))} min de lectura
+                </span>
+              </div>
+            </header>
 
-          <article
-            className="prose prose-invert prose-zinc max-w-none
-              prose-headings:font-bold prose-headings:text-zinc-100
-              prose-p:text-zinc-300 prose-p:leading-relaxed
-              prose-a:text-blue-400 hover:prose-a:text-blue-300
-              prose-strong:text-zinc-100
-              prose-code:text-cyan-400 prose-code:bg-white/[0.06] prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:font-mono
-              prose-pre:bg-zinc-900 prose-pre:border prose-pre:border-white/[0.08] prose-pre:rounded-xl
-              prose-blockquote:border-l-blue-500 prose-blockquote:text-zinc-400
-              prose-img:rounded-xl prose-img:border prose-img:border-white/[0.06]
-              prose-hr:border-white/[0.06]"
-            dangerouslySetInnerHTML={{ __html: contentHtml }}
-          />
+            {coverUrl && (
+              <div className="relative w-full h-64 md:h-80 rounded-2xl overflow-hidden mb-10 border border-white/[0.06]">
+                <Image
+                  src={coverUrl}
+                  alt={post.title}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 768px) 100vw, 720px"
+                  priority
+                />
+              </div>
+            )}
 
-          <div className="mt-12 pt-8 border-t border-white/[0.06]">
+            <article
+              className="prose prose-lg prose-invert prose-zinc max-w-none
+                prose-headings:font-bold prose-headings:text-zinc-100
+                prose-p:text-zinc-300 prose-p:leading-relaxed
+                prose-a:text-blue-400 hover:prose-a:text-blue-300
+                prose-strong:text-zinc-100
+                prose-code:text-cyan-400 prose-code:bg-white/[0.06] prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:font-mono
+                prose-pre:bg-zinc-950 prose-pre:border prose-pre:border-white/[0.08] prose-pre:rounded-xl
+                prose-blockquote:border-l-blue-500 prose-blockquote:text-zinc-400
+                prose-img:rounded-xl prose-img:border prose-img:border-white/[0.06]
+                prose-hr:border-white/[0.06]"
+              dangerouslySetInnerHTML={{ __html: contentHtml }}
+            />
+
+          </div>
+
+          {/* Share — outside the card */}
+          <div className="mb-8">
             <p className="text-sm text-zinc-500 mb-4">Compartir</p>
             <div className="flex gap-3">
               <a
@@ -243,17 +250,18 @@ export default async function PostPage({ params }: Props) {
             </div>
           </div>
 
+          {/* Prev / next — outside the card */}
           {(prev || next) && (
             <nav
               aria-label="Navegación entre posts"
-              className="mt-10 pt-8 border-t border-white/[0.06] grid grid-cols-1 sm:grid-cols-2 gap-4"
+              className="pt-6 border-t border-white/[0.06] grid grid-cols-1 sm:grid-cols-2 gap-4"
             >
               {next && (
                 <Link
                   href={`/blog/${next.slug}`}
                   className="flex flex-col gap-1 p-4 rounded-xl glass glass-hover transition-all duration-200 group"
                 >
-                  <span className="text-xs text-zinc-600">← Anterior</span>
+                  <span className="text-xs text-zinc-500">← Anterior</span>
                   <span className="text-sm text-zinc-300 group-hover:text-zinc-100 transition-colors leading-snug">
                     {next.title}
                   </span>
@@ -264,7 +272,7 @@ export default async function PostPage({ params }: Props) {
                   href={`/blog/${prev.slug}`}
                   className="flex flex-col gap-1 p-4 rounded-xl glass glass-hover transition-all duration-200 group sm:text-right sm:items-end"
                 >
-                  <span className="text-xs text-zinc-600">Siguiente →</span>
+                  <span className="text-xs text-zinc-500">Siguiente →</span>
                   <span className="text-sm text-zinc-300 group-hover:text-zinc-100 transition-colors leading-snug">
                     {prev.title}
                   </span>

--- a/app/(site)/blog/page.tsx
+++ b/app/(site)/blog/page.tsx
@@ -111,7 +111,7 @@ export default async function BlogPage() {
             </h1>
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             {posts.map((post) => {
               const coverUrl =
                 typeof post.coverImage === "object" && post.coverImage
@@ -123,14 +123,14 @@ export default async function BlogPage() {
               return (
                 <Link key={post.id} href={`/blog/${post.slug}`} className="group">
                   <GlassCard className="overflow-hidden h-full flex flex-col">
-                    <div className="h-44 bg-gradient-to-br from-blue-600/10 to-cyan-600/5 border-b border-white/[0.05] flex-shrink-0 relative overflow-hidden">
+                    <div className="h-56 bg-gradient-to-br from-blue-600/10 to-cyan-600/5 border-b border-white/[0.05] flex-shrink-0 relative overflow-hidden">
                       {coverUrl ? (
                         <Image
                           src={coverUrl}
                           alt={post.title}
                           fill
                           className="object-cover group-hover:scale-105 transition-transform duration-500"
-                          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                          sizes="(max-width: 768px) 100vw, 50vw"
                         />
                       ) : (
                         <div className="w-full h-full flex items-center justify-center">
@@ -139,8 +139,8 @@ export default async function BlogPage() {
                       )}
                     </div>
 
-                    <div className="p-6 flex flex-col gap-3 flex-1">
-                      <div className="flex items-center gap-2 text-xs text-zinc-600">
+                    <div className="p-7 flex flex-col gap-4 flex-1">
+                      <div className="flex items-center gap-2 text-xs text-zinc-500">
                         {publishedAt && (
                           <>
                             <time dateTime={publishedAt}>
@@ -152,15 +152,15 @@ export default async function BlogPage() {
                         <span>{readingTime(post.content as object)} min de lectura</span>
                       </div>
 
-                      <h2 className="text-lg font-semibold text-zinc-100 group-hover:text-blue-300 transition-colors duration-200 leading-snug">
+                      <h2 className="text-xl font-semibold text-zinc-100 group-hover:text-blue-300 transition-colors duration-200 leading-snug">
                         {post.title}
                       </h2>
 
-                      <p className="text-sm text-zinc-500 leading-relaxed flex-1">
+                      <p className="text-base text-zinc-400 leading-relaxed flex-1">
                         {post.excerpt}
                       </p>
 
-                      <div className="flex flex-wrap gap-1.5">
+                      <div className="flex flex-wrap gap-1.5 pt-1">
                         {tags.map((tag: string) => (
                           <Badge key={tag}>{tag}</Badge>
                         ))}

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,8 +17,8 @@ body {
 
 @layer utilities {
   .glass {
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.12);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
   }


### PR DESCRIPTION
…inition

- Blog post: widen container to 960px, wrap content in reading card (bg-zinc-800/50 + backdrop-blur) with prose-lg body text
- Blog list: switch to 2-col grid with larger covers (h-56), bigger type and spacing — more breathing room per card
- Bio: bigger profile photo (256px), restore gallery with aspect-ratio placeholder grid, remove empty social-proof section
- globals.css: strengthen .glass border from 0.08 to 0.12 opacity so cards are clearly visible on all display calibrations